### PR TITLE
Enable dry run option and show that the app/router.js is being changed

### DIFF
--- a/blueprints/scaffold/index.js
+++ b/blueprints/scaffold/index.js
@@ -6,6 +6,7 @@ var buildNaming          = require('../../lib/utilities/entity').buildNaming;
 var addScaffoldRoutes    = require('../../lib/utilities/scaffold-routes-generator').addScaffoldRoutes;
 var removeScaffoldRoutes = require('../../lib/utilities/scaffold-routes-generator').removeScaffoldRoutes;
 var Blueprint            = require('../../lib/blueprint/ext');
+var chalk                = require('chalk');
 
 module.exports = Blueprint.extend({
   anonymousOptions: [
@@ -32,18 +33,26 @@ module.exports = Blueprint.extend({
     return locals;
   },
   afterInstall: function(options) {
-    var target = options.target;
-    var routerFile = path.join(target, 'app', 'router.js');
-
-    addScaffoldRoutes(routerFile, this.locals(options));
+    this._addScaffoldRoutes(options);
     return this.invoke('model');
   },
   afterUninstall: function(options) {
-    var target = options.target;
-    var routerFile = path.join(target, 'app', 'router.js');
-
-    removeScaffoldRoutes(routerFile, this.locals(options));
+    this._removeScaffoldRoutes(options);
     return this.invoke('model');
   },
+  _addScaffoldRoutes: function(options) {
+    var routerFile = path.join(options.target, 'app', 'router.js');
+    this._writeStatusToUI(chalk.green, 'change', 'app/router.js');
+    if(!options.dryRun) {
+      addScaffoldRoutes(routerFile, this.locals(options));
+    }
+  },
+  _removeScaffoldRoutes: function(options) {
+    var routerFile = path.join(options.target, 'app', 'router.js');
+    this._writeStatusToUI(chalk.red, 'change', 'app/router.js');
+    if(!options.dryRun) {
+      removeScaffoldRoutes(routerFile, this.locals(options));
+    }
+  }
 });
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "chalk": "1.0.0",
     "mocha": "^2.0.1",
     "walk-sync": "^0.1.3"
   },

--- a/tests/unit/blueprints/scaffold-test.js
+++ b/tests/unit/blueprints/scaffold-test.js
@@ -7,6 +7,7 @@ var remove            = Promise.denodeify(fs.remove);
 var assert            = require('assert');
 var path              = require('path');
 var walkSync          = require('walk-sync');
+var chalk             = require('chalk');
 var testHelper        = require('../test-helper');
 var projectPath       = testHelper.projectPath;
 var fixturePath       = testHelper.fixturePath;
@@ -17,9 +18,10 @@ describe('scaffold blueprint', function() {
   var blueprint;
   var options;
   var entityName;
+  var ui;
 
   beforeEach(function() {
-    var ui = new MockUI();
+    ui = new MockUI();
     var project = new MockProject();
     MockProject.prototype.blueprintLookupPaths = function() {
       return [lookupPath];
@@ -134,6 +136,15 @@ describe('scaffold blueprint', function() {
         assert.fileEqual(fixturePath('fixture-adapter'), projectPath('app', 'adapters', 'user.js'));
       });
     });
+
+    it('displays the change in app/router.js', function() {
+      options.entity.name = 'user';
+      options.entity.options = { first_name: 'string', last_name: 'string' };
+
+      return blueprint.install(options).then(function() {
+        assert.ok(ui.output.indexOf(chalk.green('change') + ' app/router.js') !== -1);
+      });
+    });
   });
 
   describe('uninstall', function() {
@@ -224,6 +235,14 @@ describe('scaffold blueprint', function() {
       });
     });
 
+    it('displays the change in app/router.js', function() {
+      options.entity.name = 'user';
+      options.entity.options = { first_name: 'string', last_name: 'string' };
+
+      return blueprint.uninstall(options).then(function() {
+        assert.ok(ui.output.indexOf(chalk.red('change') + ' app/router.js') !== -1);
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Running the command with --dry-run should not touch the router.js.
Also display a `change app/router.js` to let the user knows this file is changed
