### PR TITLE
Misc fixes for save-model-mixin:

### DIFF
--- a/blueprints/scaffold-mixin/files/__root__/mixins/__name__/save-model-mixin.js
+++ b/blueprints/scaffold-mixin/files/__root__/mixins/__name__/save-model-mixin.js
@@ -11,11 +11,10 @@ export default Ember.Mixin.create({
       });
     }
   },
-  deactivate: function() {
-    if (this.currentModel.get('isNew')) {
-      this.currentModel.deleteRecord();
-    } else {
-      this.currentModel.rollbackAttributes();
-    }
-  }
+
+  willTransition() {
+    this._super();
+    const record = this.controller.get('record');
+    record.rollbackAttributes();
+  },
 });

--- a/tests/fixtures/save-model-mixin
+++ b/tests/fixtures/save-model-mixin
@@ -11,11 +11,10 @@ export default Ember.Mixin.create({
       });
     }
   },
-  deactivate: function() {
-    if (this.currentModel.get('isNew')) {
-      this.currentModel.deleteRecord();
-    } else {
-      this.currentModel.rollbackAttributes();
-    }
-  }
+
+  willTransition() {
+    this._super();
+    const record = this.controller.get('record');
+    record.rollbackAttributes();
+  },
 });


### PR DESCRIPTION
- Use `willTransition`, not `deactivate`: the latter won't fire when transitioning to a different model within the same route.
- Use `Model#rollbackAttributes` both for new and existing records: it not only discards changes, but also drops unpersisted records from the store.
- Always call `this._super()` on framework hooks: as explained by Robert Jackson at https://youtu.be/7kU5lLnEtJs?t=4m24s
