### PR TITLE
Destroy records "the Ember way"

### DIFF
--- a/blueprints/scaffold-acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/scaffold-acceptance-test/files/tests/acceptance/__name__-test.js
@@ -3,22 +3,13 @@ import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 
 var application;
-var originalConfirm;
-var confirmCalledWith;
 
 module('Acceptance: <%= classifiedModuleName %>', {
   beforeEach: function() {
     application = startApp();
-    originalConfirm = window.confirm;
-    window.confirm = function() {
-      confirmCalledWith = [].slice.call(arguments);
-      return true;
-    };
   },
   afterEach: function() {
     Ember.run(application, 'destroy');
-    window.confirm = originalConfirm;
-    confirmCalledWith = null;
   }
 });
 
@@ -91,14 +82,17 @@ test('show an existing <%= dasherizedModuleName %>', function(assert) {
   });
 });
 
-test('delete a <%= dasherizedModuleName %>', function(assert) {
+test('destroy a <%= dasherizedModuleName %>', function(assert) {
   server.create('<%= dasherizedModuleName %>');
   visit('/<%= dasherizedModuleNamePlural %>');
-  click('a:contains(Remove)');
+  click('a:contains(Destroy)');
+
+  andThen(function() {
+    click('input:submit');
+  });
 
   andThen(function() {
     assert.equal(currentPath(), '<%= dasherizedModuleNamePlural %>.index');
-    assert.deepEqual(confirmCalledWith, ['Are you sure?']);
     assert.equal(find('#blankslate').length, 1);
   });
 });

--- a/blueprints/scaffold-route/files/__root__/__path__/__name__/destroy.js
+++ b/blueprints/scaffold-route/files/__root__/__path__/__name__/destroy.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  actions: {
+    confirm(record) {
+      record.destroyRecord()
+        .then(() => this.transitionTo('<%= dasherizedModuleNamePlural %>'));
+    },
+  }
+});

--- a/blueprints/scaffold-route/files/__root__/__path__/__name__/index.js
+++ b/blueprints/scaffold-route/files/__root__/__path__/__name__/index.js
@@ -1,13 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  actions: {
-    remove: function(model) {
-      if(confirm('Are you sure?')) {
-        model.destroyRecord();
-      }
-    }
-  },
   model: function() {
     return this.store.findAll('<%= dasherizedModuleName %>');
   }

--- a/blueprints/scaffold-route/index.js
+++ b/blueprints/scaffold-route/index.js
@@ -8,7 +8,8 @@ var buildNaming = require('../../lib/utilities/entity').buildNaming;
 var filesToPodFilesMapping = {
   '__root__/__path__/__name__/edit.js': '__root__/__path__/edit/__name__.js',
   '__root__/__path__/__name__/index.js': '__root__/__path__/index/__name__.js',
-  '__root__/__path__/__name__/new.js': '__root__/__path__/new/__name__.js'
+  '__root__/__path__/__name__/new.js': '__root__/__path__/new/__name__.js',
+  '__root__/__path__/__name__/destroy.js': '__root__/__path__/destroy/__name__.js'
 };
 
 module.exports = {

--- a/blueprints/scaffold-template/files/__root__/__path__/__name__/destroy.hbs
+++ b/blueprints/scaffold-template/files/__root__/__path__/__name__/destroy.hbs
@@ -1,0 +1,5 @@
+<p>Are you sure?</p>
+
+<form {{action "confirm" model on="submit"}}>
+  <p><input type="submit" value="Confirm to destroy"> or {{#link-to "<%= dasherizedModuleNamePlural %>"}}cancel{{/link-to}}</p>
+</form>

--- a/blueprints/scaffold-template/files/__root__/__path__/__name__/index.hbs
+++ b/blueprints/scaffold-template/files/__root__/__path__/__name__/index.hbs
@@ -29,7 +29,7 @@
             {{link-to "Show" "<%= dasherizedModuleNamePlural %>.show" <%= camelizedModuleName %>}}
           </td>
           <td>
-            <a href="#" {{action "remove" <%= camelizedModuleName %>}}>Remove</a>
+            {{link-to "Destroy" "<%= dasherizedModuleNamePlural %>.destroy" <%= camelizedModuleName %>}}
           </td>
         </tr>
       {{/each}}

--- a/blueprints/scaffold-template/index.js
+++ b/blueprints/scaffold-template/index.js
@@ -10,7 +10,8 @@ var filesToPodFilesMapping = {
   '__root__/__path__/__name__/edit.hbs': '__root__/__path__/edit/__name__.hbs',
   '__root__/__path__/__name__/index.hbs': '__root__/__path__/index/__name__.hbs',
   '__root__/__path__/__name__/new.hbs': '__root__/__path__/new/__name__.hbs',
-  '__root__/__path__/__name__/show.hbs': '__root__/__path__/show/__name__.hbs'
+  '__root__/__path__/__name__/show.hbs': '__root__/__path__/show/__name__.hbs',
+  '__root__/__path__/__name__/destroy.hbs': '__root__/__path__/destroy/__name__.hbs'
 };
 
 module.exports = {

--- a/lib/utilities/scaffold-routes-generator.js
+++ b/lib/utilities/scaffold-routes-generator.js
@@ -11,6 +11,7 @@ function addScaffoldRoutes(routerFile, options) {
     .add(options.dasherizedModuleNamePlural + '/new')
     .add(options.dasherizedModuleNamePlural + '/edit', { path: ':' + options.dasherizedModuleName + '_id/edit' })
     .add(options.dasherizedModuleNamePlural + '/show', { path: ':' + options.dasherizedModuleName + '_id' })
+    .add(options.dasherizedModuleNamePlural + '/destroy', { path: ':' + options.dasherizedModuleName + '_id/destroy' })
     .code();
 
   if(!options.dryRun) {

--- a/tests/fixtures/destroy-route
+++ b/tests/fixtures/destroy-route
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  actions: {
+    confirm(record) {
+      record.destroyRecord()
+        .then(() => this.transitionTo('bros'));
+    },
+  }
+});

--- a/tests/fixtures/destroy-template
+++ b/tests/fixtures/destroy-template
@@ -1,0 +1,5 @@
+<p>Are you sure?</p>
+
+<form {{action "confirm" model on="submit"}}>
+  <p><input type="submit" value="Confirm to destroy"> or {{#link-to "users"}}cancel{{/link-to}}</p>
+</form>

--- a/tests/fixtures/index-route
+++ b/tests/fixtures/index-route
@@ -1,13 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  actions: {
-    remove: function(model) {
-      if(confirm('Are you sure?')) {
-        model.destroyRecord();
-      }
-    }
-  },
   model: function() {
     return this.store.findAll('bro');
   }

--- a/tests/fixtures/index-template
+++ b/tests/fixtures/index-template
@@ -35,7 +35,7 @@
             {{link-to "Show" "users.show" user}}
           </td>
           <td>
-            <a href="#" {{action "remove" user}}>Remove</a>
+            {{link-to "Destroy" "users.destroy" user}}
           </td>
         </tr>
       {{/each}}

--- a/tests/fixtures/router-with-foos-users-resource
+++ b/tests/fixtures/router-with-foos-users-resource
@@ -16,6 +16,10 @@ Router.map(function() {
     this.route('show', {
       path: ':user_id'
     });
+
+    this.route('destroy', {
+      path: ':user_id/destroy'
+    });
   });
   this.route('foos', function() {
     this.route('new');
@@ -26,6 +30,10 @@ Router.map(function() {
 
     this.route('show', {
       path: ':foo_id'
+    });
+
+    this.route('destroy', {
+      path: ':foo_id/destroy'
     });
   });
 });

--- a/tests/fixtures/router-with-users-resource
+++ b/tests/fixtures/router-with-users-resource
@@ -16,6 +16,10 @@ Router.map(function() {
     this.route('show', {
       path: ':user_id'
     });
+
+    this.route('destroy', {
+      path: ':user_id/destroy'
+    });
   });
 });
 export default Router;

--- a/tests/fixtures/user-acceptance-test
+++ b/tests/fixtures/user-acceptance-test
@@ -3,22 +3,13 @@ import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 
 var application;
-var originalConfirm;
-var confirmCalledWith;
 
 module('Acceptance: User', {
   beforeEach: function() {
     application = startApp();
-    originalConfirm = window.confirm;
-    window.confirm = function() {
-      confirmCalledWith = [].slice.call(arguments);
-      return true;
-    };
   },
   afterEach: function() {
     Ember.run(application, 'destroy');
-    window.confirm = originalConfirm;
-    confirmCalledWith = null;
   }
 });
 
@@ -94,14 +85,17 @@ test('show an existing user', function(assert) {
   });
 });
 
-test('delete a user', function(assert) {
+test('destroy a user', function(assert) {
   server.create('user');
   visit('/users');
-  click('a:contains(Remove)');
+  click('a:contains(Destroy)');
+
+  andThen(function() {
+    click('input:submit');
+  });
 
   andThen(function() {
     assert.equal(currentPath(), 'users.index');
-    assert.deepEqual(confirmCalledWith, ['Are you sure?']);
     assert.equal(find('#blankslate').length, 1);
   });
 });

--- a/tests/unit/blueprints/route-test.js
+++ b/tests/unit/blueprints/route-test.js
@@ -48,15 +48,16 @@ describe('Unit: scaffold route', function() {
 
   describe('install', function() {
 
-    it('installs the resourcefull routes', function() {
+    it('installs the resourceful routes', function() {
       options.entity.name = 'bro';
 
       return blueprint.install(options).then(function() {
         var files = walkSync(projectPath('app', 'routes')).sort();
 
-        assert.deepEqual(files, ['bros/','bros/edit.js','bros/index.js','bros/new.js']);
+        assert.deepEqual(files, ['bros/','bros/destroy.js', 'bros/edit.js','bros/index.js','bros/new.js']);
         assert.fileEqual(fixturePath('new-route'), projectPath('app', 'routes', 'bros', 'new.js'));
         assert.fileEqual(fixturePath('edit-route'), projectPath('app', 'routes', 'bros', 'edit.js'));
+        assert.fileEqual(fixturePath('destroy-route'), projectPath('app', 'routes', 'bros', 'destroy.js'));
         assert.fileEqual(fixturePath('index-route'), projectPath('app', 'routes', 'bros', 'index.js'));
       });
     });
@@ -73,6 +74,8 @@ describe('Unit: scaffold route', function() {
         var files = walkSync(projectPath('app', 'bros')).sort();
 
         assert.deepEqual(files, [
+          'destroy/',
+          'destroy/route.js',
           'edit/',
           'edit/route.js',
           'index/',
@@ -83,6 +86,7 @@ describe('Unit: scaffold route', function() {
 
         assert.fileEqual(fixturePath('new-route'), projectPath('app', 'bros', 'new', 'route.js'));
         assert.fileEqual(fixturePath('edit-route'), projectPath('app', 'bros', 'edit', 'route.js'));
+        assert.fileEqual(fixturePath('destroy-route'), projectPath('app', 'bros', 'destroy', 'route.js'));
         assert.fileEqual(fixturePath('index-route'), projectPath('app', 'bros', 'index', 'route.js'));
       });
     });
@@ -91,10 +95,10 @@ describe('Unit: scaffold route', function() {
 
   describe('uninstall', function() {
 
-    it('uninstalls the resourcefull routes', function() {
+    it('uninstalls the resourceful routes', function() {
       options.entity.name = 'bro';
 
-      ['edit.js','index.js','new.js'].forEach(function(file) {
+      ['edit.js','index.js','destroy.js', 'new.js'].forEach(function(file) {
         fs.ensureFileSync(projectPath('app', 'routes', 'bros', file));
       });
 

--- a/tests/unit/blueprints/scaffold-test.js
+++ b/tests/unit/blueprints/scaffold-test.js
@@ -72,7 +72,7 @@ describe('scaffold blueprint', function() {
       });
     });
 
-    it('add the route definition to router.js when others routes exist', function() {
+    it('add the route definition to router.js when other routes exist', function() {
       options.entity.name = 'foo';
       var targetFile = projectPath('app', 'router.js');
       fs.copySync(fixturePath('router-with-users-resource'), targetFile);

--- a/tests/unit/blueprints/template-test.js
+++ b/tests/unit/blueprints/template-test.js
@@ -50,11 +50,12 @@ describe('Unit: scaffold template', function() {
       return blueprint.install(options).then(function() {
         var files = walkSync(projectPath('app', 'templates')).sort();
 
-        assert.deepEqual(files, ['users/', 'users/-form.hbs', 'users/edit.hbs', 'users/index.hbs', 'users/new.hbs', 'users/show.hbs']);
+        assert.deepEqual(files, ['users/', 'users/-form.hbs', 'users/destroy.hbs', 'users/edit.hbs', 'users/index.hbs', 'users/new.hbs', 'users/show.hbs']);
         assert.fileEqual(fixturePath('show-template'), projectPath('app', 'templates', 'users', 'show.hbs'));
         assert.fileEqual(fixturePath('new-template'), projectPath('app', 'templates', 'users', 'new.hbs'));
         assert.fileEqual(fixturePath('index-template'), projectPath('app', 'templates', 'users', 'index.hbs'));
         assert.fileEqual(fixturePath('edit-template'), projectPath('app', 'templates', 'users', 'edit.hbs'));
+        assert.fileEqual(fixturePath('destroy-template'), projectPath('app', 'templates', 'users', 'destroy.hbs'));
         assert.fileEqual(fixturePath('form-template'), projectPath('app', 'templates', 'users', '-form.hbs'));
       });
     });
@@ -74,6 +75,8 @@ describe('Unit: scaffold template', function() {
         assert.deepEqual(files, [
           '-form/',
           '-form/template.hbs',
+          'destroy/',
+          'destroy/template.hbs',
           'edit/',
           'edit/template.hbs',
           'index/',
@@ -88,6 +91,7 @@ describe('Unit: scaffold template', function() {
         assert.fileEqual(fixturePath('new-template'), projectPath('app', 'users', 'new', 'template.hbs'));
         assert.fileEqual(fixturePath('index-template'), projectPath('app', 'users', 'index', 'template.hbs'));
         assert.fileEqual(fixturePath('edit-template'), projectPath('app', 'users', 'edit', 'template.hbs'));
+        assert.fileEqual(fixturePath('destroy-template'), projectPath('app', 'users', 'destroy', 'template.hbs'));
         assert.fileEqual(fixturePath('form-template'), projectPath('app', 'users', '-form', 'template.hbs'));
       });
     });


### PR DESCRIPTION
At the moment, the generated scaffold uses `window.confirm()` to double-check that a user wants to destroy a record. I think it should instead provide a route and a template, just like any other action:
- It demonstrates how to do this in Ember
- It allows for customisation
- It simplifies the acceptance test

I have taken the liberty of renaming it from "delete"/"remove" to "destroy", simply because I use [my research on Ember CRUDs](https://gist.github.com/pablobm/e77a98e5f3c610953a82) as a guide, and I use the term "destroy" there. I know it's a bit arbitrary!
